### PR TITLE
write-c2ffi: WITH-OUTPUT-TO-TEMPORARY-FILE from CL-FAD 0.7.2 returns a pathname

### DIFF
--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -54,9 +54,10 @@ doesn't exist, we will get a return code other than 0."
   "Write a header including the given input-file and the macro-file
 c2ffi will output.  Return the filename."
   (with-open-file (stream macro-file :direction :output :if-exists :supersede))
-  (fad:with-output-to-temporary-file (stream)
-    (format stream "#include \"~A\"~%" input-file)
-    (format stream "#include \"~A\"~%" macro-file)))
+  (namestring
+   (fad:with-output-to-temporary-file (stream)
+     (format stream "#include \"~A\"~%" input-file)
+     (format stream "#include \"~A\"~%" macro-file))))
 
 (defun run-c2ffi (input-file output-basename &key arch sysincludes)
   "Run c2ffi on `INPUT-FILE`, outputting to `OUTPUT-FILE` and


### PR DESCRIPTION
From CL-FAD 0.7.2, file `quicklisp/dists/quicklisp/software/cl-fad-0.7.2/temporary-files.lisp`:

```
(defmacro with-output-to-temporary-file ((stream &rest args) &body body)
  "Create a temporary file using OPEN-TEMPORARY with ARGS and run BODY
  with STREAM bound to the temporary file stream.  Returns the
  pathname of the file that has been created.  See OPEN-TEMPORARY for
  permitted options."
  `(with-open-stream (,stream (open-temporary ,@args))
     ,@body
     (pathname ,stream)))
```
