### PR TITLE
Allow dereference of foreign unions.  This enables:

### DIFF
--- a/plus-c/plus-c.lisp
+++ b/plus-c/plus-c.lisp
@@ -148,6 +148,11 @@
            (setf (autowrap::wrapper-validity ,v) ,*topmost-parent*)
            ,v))))
 
+(defmethod build-ref ((ref null) (type foreign-enum) current-ref rest)
+  (if *final-value-set*
+      `(cffi-sys:%mem-set ,*final-value-set* ,current-ref ,(foreign-type type))
+      `(cffi-sys:%mem-ref ,current-ref ,(foreign-type type))))
+
  ;; c-let
 
 (defun make-bindings (bindings rest)


### PR DESCRIPTION
``` c
typedef enum { /*< prefix=CLUTTER >*/
  CLUTTER_NOTHING = 0,
  CLUTTER_KEY_PRESS,
  /* ... snip ... */
} ClutterEventType;

union _ClutterEvent
{
  /*< private >*/
  ClutterEventType type;

  ClutterAnyEvent any;
  /* ... snip ... */
};
typedef union _ClutterEvent ClutterEvent;
```

``` lisp
(c-let ((event clutter-event))
   (c-ref event clutter-event :type))
```
