### PR TITLE
Fix for win64 (build of sdl2)

### DIFF
--- a/autowrap/alloc.lisp
+++ b/autowrap/alloc.lisp
@@ -5,11 +5,11 @@
     (map nil
          (lambda (x)
            (push (cons (foreign-type-size x) x) unsigned))
-         '(:unsigned-char :unsigned-int :unsigned-long))
+         '(:unsigned-char :unsigned-int :unsigned-long :unsigned-long-long))
     (map nil
          (lambda (x)
            (push (cons (foreign-type-size x) x) signed))
-         '(:char :int :long))
+         '(:char :int :long :long-long))
     (define-foreign-type 'int8 (aval 1 signed))
     (define-foreign-type 'uint8 (aval 1 unsigned))
     (define-foreign-type 'int16 (aval 2 signed))


### PR DESCRIPTION

Fix for recent build failure of SDL2 on Windows 64.
You gotta add :long-long and :unsigned-long-long to basic types because sizeof(long) == 4 !! on Win64. Surprise.

Signed-off-by: vi <vi@serenity>