### PR TITLE
Override :exclude-(include-)sources with :include-(exclude-)definitions

### DIFF
--- a/autowrap/parse.lisp
+++ b/autowrap/parse.lisp
@@ -347,9 +347,11 @@ Return the appropriate CFFI name."))
         as location = (aval :location form)
         unless
         (and (or (included-p name exclude-definitions)
-                 (included-p location exclude-sources))
+                 (and (included-p location exclude-sources)
+                      (not (included-p name include-definitions))))
              (not (or (included-p name include-definitions)
-                      (included-p location include-sources))))
+                      (and (included-p location include-sources)
+                           (not (included-p name exclude-definitions))))))
         collect (parse-form form (aval :tag form)) into forms
         finally (return (remove-if #'null forms))))
 


### PR DESCRIPTION
For including and excluding definitions accordingly providing more fine-grained control over imported symbols.

Example:
```common lisp
(autowrap:c-include "lib.h"
 :exclude-sources (".*.h")
 :include-sources ("foobar.h")   ; include symbols only from this header
 :exclude-definitions ("fbBaz")) ; although this function from "foobar.h" is still irrelevant and 
                                 ; we don't need it
```