### PR TITLE
New parameter :macro-constants to C-INCLUDE to manually specify compile-time constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,27 @@ functions, or similar, while not necessarily importing everything:
 * `:extern-package PACKAGE`: All "extern" symbols, which are all
   symbols (which are symbol-macros) representing C `extern` symbols
 
+
+#### C2FFI and compile-time constants
+
+Currently `c2ffi` extracts binding information from C-sources in two stages.
+First stage is to look through all the preprocessor macros and extract
+information about all compile-time constants.
+Second stage is to extract information about all the other bindings.
+
+Sometimes `c2ffi` does not get the first stage right
+(by trying to interpret as constants things that are not constants at all).
+
+In this case you may want to manually provide the list of compile-time constants.
+You can do this with `:macro-constants LIST-OF-TYPE-NAME-PAIRS` parameter to `c-include`,
+for example:
+
+```lisp
+(c-include "file.h"
+           :macro-constants '(("char*" "FOO")
+	                      ("long" "BAR")))
+```
+
 ## Wrappers and FFI
 
 At this point you probably have definitions generated (or are

--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -71,7 +71,7 @@ doesn't exist, we will get a return code other than 0."
       ,@body)
     :keep ,keep))
 
-(defun run-c2ffi (input-file output-basename &key arch sysincludes ignore-error-status)
+(defun run-c2ffi (input-file output-basename &key arch sysincludes ignore-error-status macro-constants)
   "Run c2ffi on `INPUT-FILE`, outputting to `OUTPUT-FILE` and
 `MACRO-OUTPUT-FILE`, optionally specifying a target triple `ARCH`."
   (with-temporary-file (:pathname tmp-macro-file
@@ -81,12 +81,19 @@ doesn't exist, we will get a return code other than 0."
            (sysincludes (loop for dir in sysincludes
                               append (list "-i" dir))))
       ;; Invoke c2ffi to emit macros into TMP-MACRO-FILE
-      (when (run-check *c2ffi-program* (list* (namestring input-file)
-                                              "-D" "null"
-                                              "-M" (namestring tmp-macro-file)
-                                              (append arch sysincludes))
-                       :output *standard-output*
-                       :ignore-error-status ignore-error-status)
+      (when (if (eq :auto macro-constants)
+                (progn (format t "Trying to generate macro constants automatically")
+                       (run-check *c2ffi-program* (list* (namestring input-file)
+                                                         "-D" "null"
+                                                         "-M" (namestring tmp-macro-file)
+                                                         (append arch sysincludes))
+                                  :output *standard-output*
+                                  :ignore-error-status ignore-error-status))
+                (progn (format t "Using manually provided list of macro constants~%")
+                       (with-open-file (stream tmp-macro-file :direction :output :if-exists :supersede)
+                         (loop for spec in macro-constants
+                            do (format stream "const ~a __c2ffi_~a = ~a;~%" (car spec) (cadr spec) (cadr spec)))
+                         t)))
         ;; Write a tmp header file that #include's the input file and the macros file.
         (with-temporary-file (:stream tmp-include-file-stream
                               :pathname tmp-include-file
@@ -116,7 +123,8 @@ if the file does not exist."
                           (spec-path *default-pathname-defaults*)
                           arch-excludes
                           sysincludes
-                          version)
+                          version
+                          macro-constants)
   (flet ((spec-path (arch) (string+ (namestring spec-path)
                                     (pathname-name name)
                                     (if version
@@ -133,7 +141,8 @@ if the file does not exist."
             (let ((arch (local-arch)))
               (run-c2ffi name (spec-path arch)
                          :arch arch
-                         :sysincludes sysincludes))
+                         :sysincludes sysincludes
+                         :macro-constants macro-constants))
             (loop with local-arch = (local-arch)
                   for arch in *known-arches* do
                     (unless (or (string= local-arch arch)
@@ -141,7 +150,8 @@ if the file does not exist."
                       (unless (run-c2ffi name (spec-path arch)
                                          :arch arch
                                          :sysincludes sysincludes
-                                         :ignore-error-status t)
+                                         :ignore-error-status t
+                                         :macro-constants macro-constants)
                         (warn "Error generating spec for other arch: ~S" arch))))
             (if-let (h-name (find-local-spec name spec-path))
               h-name

--- a/autowrap/conditions.lisp
+++ b/autowrap/conditions.lisp
@@ -13,12 +13,6 @@
              (with-slots (typespec) c
                (format s "~@<Undefined foreign type: ~A~:@>" typespec)))))
 
-(define-condition note-error (autowrap-continuable-error)
-  ((note                     :initarg :note))
-  (:report (lambda (c s)
-             (with-slots (note) c
-               (format s "~@<Note: ~A~:@>" note)))))
-
 (define-condition undefined-foreign-type-contextualised (undefined-foreign-type)
   ((context-format-control   :initarg :context-format-control)
    (context-format-arguments :initarg :context-format-arguments))

--- a/autowrap/conditions.lisp
+++ b/autowrap/conditions.lisp
@@ -13,6 +13,12 @@
              (with-slots (typespec) c
                (format s "~@<Undefined foreign type: ~A~:@>" typespec)))))
 
+(define-condition note-error (autowrap-continuable-error)
+  ((note                     :initarg :note))
+  (:report (lambda (c s)
+             (with-slots (note) c
+               (format s "~@<Note: ~A~:@>" note)))))
+
 (define-condition undefined-foreign-type-contextualised (undefined-foreign-type)
   ((context-format-control   :initarg :context-format-control)
    (context-format-arguments :initarg :context-format-arguments))

--- a/autowrap/parse.lisp
+++ b/autowrap/parse.lisp
@@ -392,9 +392,9 @@ Return the appropriate CFFI name."))
                      sysincludes
                      (definition-package *package*)
                      (function-package definition-package)
-                     (wrapper-package definition-package)
+                     (wrapper-package function-package)
                      (accessor-package wrapper-package)
-                     (constant-package definition-package)
+                     (constant-package accessor-package)
                      (extern-package accessor-package)
                      constant-accessor exclude-constants
                      (trace-c2ffi *trace-c2ffi*) no-accessors no-functions

--- a/autowrap/parse.lisp
+++ b/autowrap/parse.lisp
@@ -399,7 +399,8 @@ Return the appropriate CFFI name."))
                      constant-accessor exclude-constants
                      (trace-c2ffi *trace-c2ffi*) no-accessors no-functions
                      release-p version
-                     type-symbol-function c-to-lisp-function)
+                     type-symbol-function c-to-lisp-function
+                     (macro-constants nil macro-constants-p))
   (let ((*foreign-symbol-exceptions* (alist-hash-table symbol-exceptions :test 'equal))
         (*foreign-symbol-regex* (make-scanners symbol-regex))
         (*foreign-constant-excludes* (mapcar #'ppcre:create-scanner exclude-constants))
@@ -423,14 +424,18 @@ Return the appropriate CFFI name."))
         (constant-package (find-package constant-package))
         (extern-package (find-package extern-package))
         (constant-name-value-map (gensym "CONSTANT-NAME-VALUE-MAP-"))
-        (old-mute-reporting *mute-reporting-p*))
+        (old-mute-reporting *mute-reporting-p*)
+        (macro-constants (if macro-constants-p
+                             (eval macro-constants)
+                             :auto)))
     (multiple-value-bind (spec-name)
         (let ((*trace-c2ffi* trace-c2ffi))
           (ensure-local-spec h-file
                              :spec-path spec-path
                              :arch-excludes exclude-arch
                              :sysincludes sysincludes
-                             :version version))
+                             :version version
+                             :macro-constants macro-constants))
       (with-open-file (in-spec spec-name)
         (collecting-symbols
           `(progn


### PR DESCRIPTION
Hi!

I'm now making bindings for Poppler library using cl-autowrap
and I needed this manual specification of compile-time constants
(so that C2FFI does not try to guess them, using the preprocessor),
because C2FFI was getting them wrong because of peculiar syntax inside the header files.

I hope you'll find this useful.