### PR TITLE
Spec processing

### DIFF
--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -108,7 +108,7 @@ doesn't exist, we will get a return code other than 0."
                        :output *standard-output*
                        :ignore-error-status ignore-error-status)
             (with-open-file (raw-input tmp-raw-output)
-              (with-open-file (final-output output-spec :direction :output)
+              (with-open-file (final-output output-spec :direction :output :if-exists :supersede)
                 (funcall spec-processor raw-input final-output)))))))))
  ;; Specs and Loading
 
@@ -126,7 +126,8 @@ if the file does not exist."
                           (spec-path *default-pathname-defaults*)
                           arch-excludes
                           sysincludes
-                          version)
+                          version
+                          spec-processor)
   (flet ((spec-path (arch) (string+ (namestring spec-path)
                                     (pathname-name name)
                                     (if version
@@ -143,7 +144,8 @@ if the file does not exist."
             (let ((arch (local-arch)))
               (run-c2ffi name (spec-path arch)
                          :arch arch
-                         :sysincludes sysincludes))
+                         :sysincludes sysincludes
+                         :spec-processor spec-processor))
             (loop with local-arch = (local-arch)
                   for arch in *known-arches* do
                     (unless (or (string= local-arch arch)
@@ -151,7 +153,8 @@ if the file does not exist."
                       (unless (run-c2ffi name (spec-path arch)
                                          :arch arch
                                          :sysincludes sysincludes
-                                         :ignore-error-status t)
+                                         :ignore-error-status t
+                                         :spec-processor spec-processor)
                         (warn "Error generating spec for other arch: ~S" arch))))
             (if-let (h-name (find-local-spec name spec-path))
               h-name

--- a/autowrap/processing.lisp
+++ b/autowrap/processing.lisp
@@ -1,0 +1,123 @@
+(in-package :autowrap)
+
+
+(defun make-descriptor (&rest pairs &key &allow-other-keys)
+  (plist-alist pairs))
+
+(defun make-stub-struct (descriptor)
+  (flet ((%val (name)
+           (aval name descriptor)))
+    (let ((bit-size (%val :bit-size))
+          (bit-alignment (%val :bit-alignment)))
+
+      (multiple-value-bind (byte-size remainder) (floor (/ bit-size 8))
+        (unless (= remainder 0)
+          (error "Unexpected bitsize: expected multiple of 8, but got ~a" bit-size))
+        (make-descriptor
+         :tag "struct"
+         :ns (%val :ns)
+         :name (%val :name)
+         :id (%val :id)
+         :location (%val :location)
+         :bit-size bit-size
+         :bit-alignment bit-alignment
+         :fields (vector (make-descriptor
+                          :tag "field"
+                          :name "_data"
+                          :bit-offset 0
+                          :bit-size bit-size
+                          :bit-alignment bit-alignment
+                          :type (make-descriptor
+                                 :tag ":array"
+                                 :size byte-size
+                                 :type (make-descriptor
+                                        :tag ":char"
+                                        :bit-size 8
+                                        :bit-alignment 8)))))))))
+
+
+(defun extract-field-type (descriptor)
+  (switch ((aval :tag descriptor) :test #'equal)
+    (":pointer" (list (extract-pointer-type (aval :type descriptor))))
+    (":struct" (list (aval :name descriptor)))
+    ("union" (extract-union-types descriptor))
+    (t (list (aval :tag descriptor)))))
+
+(defun extract-union-types (descriptor)
+  (loop for field in (aval :fields descriptor)
+     append (extract-field-type (aval :type field))))
+
+(defun extract-typedef-type (descriptor)
+  (switch ((aval :tag descriptor) :test #'equal)
+    ("struct" (list (aval :name descriptor)))
+    (":struct" (list (aval :name descriptor)))
+    ("union" (extract-union-types descriptor))
+    (":enum" (list (aval :name descriptor)))
+    (t (list (aval :tag descriptor)))))
+
+(defun extract-pointer-type (descriptor)
+  (switch ((aval :tag descriptor) :test #'equal)
+    ("struct" (aval :name descriptor))
+    (":struct" (aval :name descriptor))
+    (":pointer" (extract-pointer-type (aval :type descriptor)))
+    (t (aval :tag descriptor))))
+
+(defun extract-function-parameter-type (descriptor)
+  (switch ((aval :tag descriptor) :test #'equal)
+    (":pointer" (extract-pointer-type (aval :type descriptor)))
+    (t (aval :tag descriptor))))
+
+(defun extract-dependent-types (descriptor)
+  (switch ((aval :tag descriptor) :test #'equal)
+    ("typedef" (extract-typedef-type (aval :type descriptor)))
+    ("struct"
+     (loop for field in (aval :fields descriptor)
+        append (extract-field-type (aval :type field))))
+    ("function"
+     (cons (extract-function-parameter-type (aval :return-type descriptor))
+           (loop for parameter in (aval :parameters descriptor)
+              collect (extract-function-parameter-type (aval :type parameter)))))))
+
+(defun fill-name-set (raw-spec name-set)
+  (loop for form in raw-spec
+       as name = (aval :name form)
+       as location = (aval :location form)
+       unless (excluded-p name location)
+       do (loop for name in (append (list name) (extract-dependent-types form))
+             unless (or (emptyp name) (starts-with #\: name))
+             do (setf (gethash name name-set) t))))
+
+(defun follow-typedefs (raw-spec name-set)
+  (loop with unregistered-typedef-found-p = nil
+     for descriptor in raw-spec
+     as tag = (aval :tag descriptor)
+     as name = (aval :name descriptor)
+     when (and (equal "typedef" tag) (gethash name name-set))
+     do (loop for type in (extract-typedef-type (aval :type descriptor))
+             unless (gethash type name-set)
+             do (setf unregistered-typedef-found-p t
+                      (gethash type name-set) t))
+     finally (return unregistered-typedef-found-p)))
+
+(defun extract-included-name-set (raw-spec)
+  (let ((name-set (make-hash-table :test 'equal)))
+    (fill-name-set raw-spec name-set)
+    (loop while (follow-typedefs raw-spec name-set))
+    name-set))
+
+(defun process-descriptor (descriptor)
+  (let ((type (aval :tag descriptor)))
+    (if (and (excluded-p (aval :name descriptor) (aval :location descriptor))
+             (not (or (equal "typedef" type)
+                      (equal "enum" type)
+                      (equal "function" type))))
+        (make-stub-struct descriptor)
+        descriptor)))
+
+(defun squash-unrelated-definitions (input-spec-stream output-spec-stream)
+  (let* ((raw-spec (read-json input-spec-stream))
+         (name-set (extract-included-name-set raw-spec))
+         (descriptors (loop for descriptor in raw-spec
+                         when (gethash (aval :name descriptor) name-set)
+                         collect (process-descriptor descriptor))))
+    (json:encode-json descriptors output-spec-stream)))

--- a/autowrap/processing.lisp
+++ b/autowrap/processing.lisp
@@ -40,19 +40,22 @@ of array type taking all the struct available space"
   (loop for field in (aval :fields descriptor)
      append (extract-type (aval :type field))))
 
-(defun extract-type (type-descriptor)
-  (switch ((aval :tag type-descriptor) :test #'equal)
-    (":pointer" (list (extract-type (aval :type type-descriptor))))
-    ("struct" (list (aval :name type-descriptor)))
-    (":struct" (list (aval :name type-descriptor)))
-    ("union" (extract-field-types type-descriptor))
-    (":enum" (list (aval :name type-descriptor)))
-    (t (list (aval :tag type-descriptor)))))
-
 (defun extract-function-types (descriptor)
   (cons (extract-type (aval :return-type descriptor))
         (loop for parameter in (aval :parameters descriptor)
            collect (extract-type (aval :type parameter)))))
+
+(defun extract-struct-types (descriptor)
+  (cons (aval :name descriptor) (extract-field-types descriptor)))
+
+(defun extract-type (type-descriptor)
+  (switch ((aval :tag type-descriptor) :test #'equal)
+    (":pointer" (list (extract-type (aval :type type-descriptor))))
+    ("struct" (extract-struct-types type-descriptor))
+    (":struct" (extract-struct-types type-descriptor))
+    ("union" (extract-field-types type-descriptor))
+    (":enum" (list (aval :name type-descriptor)))
+    (t (list (aval :tag type-descriptor)))))
 
 (defun extract-dependent-types (descriptor)
   (switch ((aval :tag descriptor) :test #'equal)

--- a/autowrap/util.lisp
+++ b/autowrap/util.lisp
@@ -2,6 +2,11 @@
 
  ;; misc
 
+(declaim (special *include-definitions*
+                  *exclude-definitions*
+                  *include-sources*
+                  *exclude-sources*))
+
 (defun substr* (str start &optional end)
   "Make a shared substring of STR using MAKE-ARRAY :displaced-to"
   (let* ((end (or end (length str)))
@@ -84,6 +89,14 @@
       (when (cl-ppcre:scan scanner thing)
         (return t)))))
 
+(defun excluded-p (name location)
+  (and (or (included-p name *exclude-definitions*)
+           (and (included-p location *exclude-sources*)
+                (not (included-p name *include-definitions*))))
+       (not (or (included-p name *include-definitions*)
+                (and (included-p location *include-sources*)
+                     (not (included-p name *exclude-definitions*)))))))
+
 (defun anonymous-p (form)
   (etypecase form
     (foreign-type
@@ -133,7 +146,7 @@
 ;; from pergamum
 (defmacro define-simple-error-for (base-type &key name object-initarg)
   "Define a simple error subclassing from BASE-TYPE and a corresponding
-function, analogous to ERROR, but also optionally taking the object 
+function, analogous to ERROR, but also optionally taking the object
 against which to err, and passing it to ERROR via the OBJECT-INITARG
 keyword. The name of the simple error is constructed by prepending
 'SIMPLE-' to BASE-TYPE.

--- a/cl-autowrap.asd
+++ b/cl-autowrap.asd
@@ -23,6 +23,7 @@
    (:file "sffi")
    (:file "alloc")
    (:file "errno")
+   (:file "processing")
    (:file "parse")
    (:file "bitmask")))
 


### PR DESCRIPTION
Filters included names at the spec level, hence filtering  `read-parse-forms`