### PR TITLE
Fix foreign-scalar-p for unions with no members

### DIFF
--- a/autowrap/sffi.lisp
+++ b/autowrap/sffi.lisp
@@ -214,7 +214,7 @@
   (foreign-scalar-p (foreign-type field)))
 
 (defmethod foreign-scalar-p ((type foreign-record))
-  (when (eq :union (foreign-type type))
+  (when (and (eq :union (foreign-type type)) (foreign-record-fields type))
        (every #'foreign-scalar-p (foreign-record-fields type))))
 
 (defmethod foreign-scalar-p ((type list))


### PR DESCRIPTION
Union types with no members were being called scalar by
`foreign-scalar-p` when they had no members. Since it cannot be
determined if they are scalar or not, it its more correct to classify
them as non-scalar.

This fixes a bug where unions with no members were causing an error and
preventing files from being imported correctly.