### PR TITLE
Fix handling of function pointer in function parameters

### DIFF
--- a/autowrap/sffi.lisp
+++ b/autowrap/sffi.lisp
@@ -379,6 +379,9 @@ call it.  "
                                  :type return-type
                                  :variadic-p variadic-p)))
         (setf (foreign-record-fields fun)
+	      ;; one solution for function poiner params
+	      ;; is to set the parameter to be a pointer in the function params:
+	      ;; see make-foreign-funcall
               (loop for param in params
                  collect (make-instance 'foreign-field :name (car param)
                                         :type (ensure-type (cadr param) "function ~S (nee ~S) due to parameter ~S of type ~S"
@@ -689,8 +692,13 @@ types."
                          `(cffi-sys:%foreign-funcall ,c-symbol
                                                      (,@(loop for f in fields
                                                               for s in param-names
-                                                              collect (basic-foreign-type f)
-                                                              collect s)
+							   ;; see define-foreign-function for the
+							   ;; other solution for function pointers
+                                                           collect (let ((type (basic-foreign-type f)))
+								     (if (equalp type :function)
+									 :pointer
+									 type))
+							   collect s)
                                                       ,@vargs
                                                       ,(basic-foreign-type
                                                         (foreign-type fun)))


### PR DESCRIPTION
Function pointers are just that; pointers. Therefore they should be marked as a pointer in `cffi-sys:%foreign-funcall` instead of as a `:function`. Another solution is to mark the parameter types as a pointer when initializing the function object, but having a parameter's type being a pointer is not as informative as it being a function.

This removes an error that looks something like:

``` lisp
; --> PROGN EVAL-WHEN AUTOWRAP:DEFINE-CFUN PROGN DEFUN PROGN
; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION
; --> BLOCK LET LET LET
; ==>
;   (CFFI-SYS:%FOREIGN-FUNCALL "wlr_list_find"
;                              (:POINTER #:LIST13159 :FUNCTION #:COMPARE13160
;                               :POINTER #:CMP-TO13161 :LONG)
;                              :CONVENTION :CDECL)
;
; caught ERROR:
;   during macroexpansion of
;   (CFFI-SYS:%FOREIGN-FUNCALL "wlr_list_find" (:POINTER #:LIST13159 :FUNCTION ...)
;                              ...).
;   Use *BREAK-ON-SIGNALS* to intercept.
;
;    :FUNCTION fell through ECASE expression.
;    Wanted one of (:CHAR :UNSIGNED-CHAR :SHORT :UNSIGNED-SHORT :INT :UNSIGNED-INT
;                   :LONG :UNSIGNED-LONG :LONG-LONG :UNSIGNED-LONG-LONG :FLOAT
;                   :DOUBLE :POINTER :VOID).
```