### PR TITLE
Port to clasp (wrapper)

### DIFF
--- a/autowrap/wrapper.lisp
+++ b/autowrap/wrapper.lisp
@@ -9,11 +9,11 @@
 
 (declaim (inline make-wrapper wrapper-ptr))
 (defstruct wrapper
-  #+(or cmucl ecl sbcl clisp lispworks)
+  #+(or cmucl clasp ecl sbcl clisp lispworks)
   (ptr (cffi:null-pointer) :type cffi:foreign-pointer)
   #+(or ccl allegro)
   (ptr #.(cffi:null-pointer) :type cffi:foreign-pointer)
-  #-(or cmucl ecl sbcl clisp ccl allegro lispworks)
+  #-(or cmucl clasp ecl sbcl clisp ccl allegro lispworks)
   (error "Unknown Lisp. Fix appropriate condition.")
   (validity t))
 


### PR DESCRIPTION
With this change cl-sdl2 (uses cl-autowrap) works fine in clasp