### PR TITLE
Add armv7a androideabi support

### DIFF
--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -20,7 +20,7 @@
   #+(not (or linux windows darwin)) "-unknown")
 
 (defun local-os ()
-  #+linux "-linux"
+  #+(or linux android) "-linux"
   #+windows "-windows-msvc"
   #+darwin "-darwin9"
   #+freebsd "-freebsd"
@@ -28,7 +28,8 @@
 
 (defun local-environment ()
   #+linux "-gnu"
-  #-linux "")
+  #+android "-androideabi"
+  #+(not (or linux android)) "")
 
 (defun local-arch ()
   (string+ (local-cpu) (local-vendor) (local-os) (local-environment)))
@@ -44,7 +45,8 @@
     "x86_64-unknown-freebsd"
     "i386-unknown-openbsd"
     "x86_64-unknown-openbsd"
-    "arm-pc-linux-gnu"))
+    "arm-pc-linux-gnu"
+    "arm-unknown-linux-androideabi"))
 
  ;; c2ffi
 


### PR DESCRIPTION
About the https://github.com/rpav/cl-autowrap/issues/98.

I don't added support to arm64-v8a because the https://github.com/trivial-features/trivial-features/blob/master/src/tf-ecl.lisp#L54 doesn't support arm64 yet. Maybe I'll make that after and I'll make the changes here too. For now the armv7a spec generation woks fine. 

Why "arm-unknown-linux-androideabi" instead "armv7a-unknown-linux-androideabi"?

because by some motive the people like to call `armv7a` of `arm` only and `arm64` of `aarch64`, I think that's bad because it's confusing, but that's the way they are the names. The Triple almost never match with the ABI name.

