### PR TITLE
Add force-arch option to force load specific spec file.

### DIFF
--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -50,6 +50,8 @@
 
  ;; c2ffi
 
+(defvar *autowrap-arch-override* nil)
+
 (defvar *c2ffi-program* "c2ffi")
 
 (defvar *trace-c2ffi* nil)
@@ -107,7 +109,7 @@ doesn't exist, we will get a return code other than 0."
 (defun find-local-spec (name &optional (spec-path *default-pathname-defaults*))
   "Return the path of the SPEC for this machine's architecture, or NIL
 if the file does not exist."
-  (let* ((arch (local-arch))
+  (let* ((arch (or *autowrap-arch-override* (local-arch)))
          (name (pathname-name name))
          (h-name (make-pathname :defaults spec-path
                                 :name (string+ name "." arch)

--- a/autowrap/package.lisp
+++ b/autowrap/package.lisp
@@ -97,7 +97,7 @@
    #:define-bitmask-from-constants #:define-bitmask-from-enum
 
    ;; Parsing and input
-   #:c-include #:*c2ffi-program*
+   #:c-include #:*c2ffi-program* #:*autowrap-arch-override*
 
    ;; Debug
    #:*trace-c2ffi*

--- a/autowrap/parse.lisp
+++ b/autowrap/parse.lisp
@@ -389,6 +389,7 @@ Return the appropriate CFFI name."))
  ;; Exported API
 
 (defmacro c-include (h-file &key (spec-path *default-pathname-defaults*)
+                     (force-arch *autowrap-arch-override*)
                      symbol-exceptions symbol-regex
                      exclude-definitions exclude-sources exclude-arch
                      include-definitions include-sources
@@ -428,7 +429,8 @@ Return the appropriate CFFI name."))
         (constant-name-value-map (gensym "CONSTANT-NAME-VALUE-MAP-"))
         (old-mute-reporting *mute-reporting-p*))
     (multiple-value-bind (spec-name)
-        (let ((*trace-c2ffi* trace-c2ffi))
+        (let ((*trace-c2ffi* trace-c2ffi)
+              (*autowrap-arch-override* force-arch))
           (ensure-local-spec h-file
                              :spec-path spec-path
                              :arch-excludes exclude-arch


### PR DESCRIPTION
About https://github.com/rpav/cl-autowrap/issues/101. I created one `force-arch` key in c-include also, it's util when use that macro and I'm use it in the cl-sdl2. 