### PR TITLE
Add arm64 android support

### DIFF
--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -12,7 +12,8 @@
   #+x86-64 "x86_64"
   #+(and (not (or x86-64 freebsd)) x86) "i686"
   #+(and (not x86-64) x86 freebsd) "i386"
-  #+arm "arm")
+  #+arm "arm"
+  #+arm64 "aarch64")
 
 (defun local-vendor ()
   #+(or linux windows) "-pc"
@@ -28,7 +29,8 @@
 
 (defun local-environment ()
   #+linux "-gnu"
-  #+android "-androideabi"
+  #+(and arm android) "-androideabi"
+  #+(and (not arm) android) "-android"
   #+(not (or linux android)) "")
 
 (defun local-arch ()
@@ -46,7 +48,10 @@
     "i386-unknown-openbsd"
     "x86_64-unknown-openbsd"
     "arm-pc-linux-gnu"
-    "arm-unknown-linux-androideabi"))
+    "arm-unknown-linux-androideabi"
+    "aarch64-unknown-linux-android"
+    "i686-unknown-linux-android"
+    "x86_64-unknown-linux-android"))
 
  ;; c2ffi
 


### PR DESCRIPTION
About the https://github.com/rpav/cl-autowrap/issues/103.

The arm64 Triple in the [android](https://developer.android.com/ndk/guides/other_build_systems)  use  `"aarch64"` so `#+arm64 "aarch64"`. But for the clang whatever to call `arm64` or `aarch64` will work. I tested it now after this commit, either way, I'll leave it as it is.

In this [link](https://developer.android.com/ndk/guides/other_build_systems), I see `-androideabi` to `arm` and `-android` to others, so, I followed this.

In addition to `"aarch64-unknown-linux-android"` I add `"i686-unknown-linux-android"` and `"i686-unknown-linux-android"` because also are possible to generate, maybe someone need this.