### PR TITLE
change default foreign type name when it is conflict with common lisp package.

### DIFF
--- a/autowrap/sffi.lisp
+++ b/autowrap/sffi.lisp
@@ -31,8 +31,17 @@
  ;; Types
 
 (defclass foreign-type ()
-  ((name :initarg :name :initform nil :accessor foreign-type-name :type symbol)
+  ((name :initarg :name :initform nil :type symbol)
    (type :initarg :type :initform nil :accessor foreign-type :type (not null))))
+
+(defgeneric foreign-type-name (object))
+(defmethod foreign-type-name ((object foreign-type))
+  (with-slots (name) object
+     (if (and name (eq (symbol-package name) #.(find-package :cl)))
+       ;; when a symbol belongs to `:cl' package, we have to rename it to avoid name conflcit.
+       ;; for example symbol `t' is not a legal symbol name for function/structure argument in common lisp.
+       (intern (format nil "C-~A" (symbol-name name)))
+       name)))
 
 (defmethod foreign-type-name ((object symbol))
   (if (keywordp object)

--- a/autowrap/sffi.lisp
+++ b/autowrap/sffi.lisp
@@ -214,8 +214,9 @@
   (foreign-scalar-p (foreign-type field)))
 
 (defmethod foreign-scalar-p ((type foreign-record))
-  (when (eq :union (foreign-type type))
-       (every #'foreign-scalar-p (foreign-record-fields type))))
+  (when (and (eq :union (foreign-type type))
+             (foreign-record-fields type))
+    (every #'foreign-scalar-p (foreign-record-fields type))))
 
 (defmethod foreign-scalar-p ((type list))
   (let ((specifier (car type)))


### PR DESCRIPTION
In some cases, the parameter name of a C function may be "t" or other symbols in common lisp package, which make them illegal parameter name.

We have to rename them to avoid such conflict.

One case is for the following spec:
```json
{ "tag": "function", "name": "ASN1_TYPE_pack_sequence", "ns": 0, "location": "/usr/include/openssl/asn1.h:525:12", "variadic": false, "inline": false, "storage-class": "none", "parameters": [{ "tag": "parameter", "name": "it", "type": { "tag": ":pointer", "type": { "tag": "ASN1_ITEM" } } }, { "tag": "parameter", "name": "s", "type": { "tag": ":pointer", "type": { "tag": ":void" } } }, { "tag": "parameter", "name": "t", "type": { "tag": ":pointer", "type": { "tag": ":pointer", "type": { "tag": "ASN1_TYPE" } } } }], "return-type": { "tag": ":pointer", "type": { "tag": "ASN1_TYPE" } } },

```