### PR TITLE
foreign-type type initform cannot be nil

### DIFF
--- a/autowrap/sffi.lisp
+++ b/autowrap/sffi.lisp
@@ -32,7 +32,7 @@
 
 (defclass foreign-type ()
   ((name :initarg :name :initform nil :accessor foreign-type-name :type symbol)
-   (type :initarg :type :initform nil :accessor foreign-type :type (not null))))
+   (type :initarg :type :initform t :accessor foreign-type :type (not null))))
 
 (defmethod foreign-type-name ((object symbol))
   (if (keywordp object)


### PR DESCRIPTION
Fixes #106 

SBCL introduced more rigorous type checking in
sbcl-2.0.7-154-g16b55d78d
