### PR TITLE
Explicitly specify the language for c2ffi as `c`

### DIFF
--- a/autowrap/c2ffi.lisp
+++ b/autowrap/c2ffi.lisp
@@ -103,7 +103,7 @@ doesn't exist, we will get a return code other than 0."
           (format tmp-include-file-stream "#include \"~A\"~%" tmp-macro-file)
           (close tmp-include-file-stream)
           ;; Invoke c2ffi again to generate the final output.
-          (run-check *c2ffi-program* (list* (namestring tmp-include-file) "-o" output-spec
+          (run-check *c2ffi-program* (list* (namestring tmp-include-file) "--lang" "c" "--output" output-spec
                                             (append arch sysincludes))
                      :output *standard-output*
                      :ignore-error-status ignore-error-status))))))


### PR DESCRIPTION
I had to make this change in order to get `raylib.h` from www.raylib.com running. If we only support `c`, which I assume, then this should not break anything else. Also I changed the `-o` to `--output` because in scripts and programs I like to use the long forms of program options since it makes reading the code easier for people unfamiliar with `c2ffi`s options.

Also in order to figure this out I had to run the program arguments manually, which were given to me as an error. The helping clue was given by `c2ffi` via stderr, which was not printed. It would be great if we could also print out the content of stderr if `c2ffi` fails to help in quicker debugging.