### PR TITLE
get constructor for aliased type when trying to create wrappers

### DIFF
--- a/plus-c/plus-c.lisp
+++ b/plus-c/plus-c.lisp
@@ -251,8 +251,11 @@
                                `((let ((,tmp
                                          ,(if from
                                               from
-                                              `(let ((,tmp (,(gethash (foreign-type-name type)
-                                                                      autowrap::*wrapper-constructors*))))
+                                              `(let ((,tmp (,(if (typep type 'foreign-alias)
+                                                                 (gethash (foreign-type-name (foreign-type type))
+                                                                          autowrap::*wrapper-constructors*)
+                                                                 (gethash (foreign-type-name type)
+                                                                          autowrap::*wrapper-constructors*)))))
                                                  (setf (autowrap::wrapper-ptr ,tmp) ,ptr)
                                                  ,tmp))))
                                    ,@(maybe-make-macro bindings rest tmp v c-type nil))))


### PR DESCRIPTION
Function signatures using typedef'd types try to get the wrong constructor. Fix is to get the constructor for the aliased type.

Ran into this when trying to wrap raylib which has definitions that look like this:
```
typedef struct Texture {
// ...
} Texture;

typedef Texture Texture2D;

Texture2D LoadTexture(const char *fileName);
```

The wrapper for `LoadTexture` would try to call `make-texture2d` which does not exist.