### PR TITLE
Keep formal parameter name of C function as is when converting to symbol

### DIFF
--- a/autowrap/parse.lisp
+++ b/autowrap/parse.lisp
@@ -49,6 +49,7 @@
 (defun default-foreign-type-symbol (string type package)
   (let ((string (or (and *foreign-symbol-exceptions*
                          (gethash string *foreign-symbol-exceptions*))
+                    (and (eq type :cparam) string)
                     (funcall *foreign-c-to-lisp-function*
                              (if *foreign-symbol-regex*
                                  (apply-regexps string *foreign-symbol-regex*)


### PR DESCRIPTION
Fix #124

There is no need to rename and upcase the formal parameter name of C function, so just keep it as is to avoid duplication.