### PR TITLE
Accumulate nested record offsets (fixes #129)

### DIFF
--- a/autowrap/sffi.lisp
+++ b/autowrap/sffi.lisp
@@ -416,7 +416,7 @@ call it.  "
                      (ensure-list field-typespec)
                    (declare (ignore anon-params))
                    (let* ((anonymous-fields (parse-record-fields anon-record-type nil
-                                                                 anon-field-list bit-offset)))
+                                                                 anon-field-list (+ pre-offset (or bit-offset 0)))))
                      (loop for i in anonymous-fields
                            do (push i record-fields))))))
         finally (return (delete-if #'null record-fields))))


### PR DESCRIPTION
Tested with the referenced structure - accessors return correct addresses. A simple local project using `cl-sdl2` runs normally.